### PR TITLE
MULE-12609: Every exported Mule package must contain api

### DIFF
--- a/src/main/java/org/mule/service/soap/message/ImmutableSoapResponse.java
+++ b/src/main/java/org/mule/service/soap/message/ImmutableSoapResponse.java
@@ -8,10 +8,10 @@ package org.mule.service.soap.message;
 
 import static java.util.Collections.unmodifiableMap;
 import static org.mule.runtime.api.message.Message.builder;
-import static org.mule.runtime.core.message.DefaultMultiPartPayload.BODY_ATTRIBUTES;
+import static org.mule.runtime.core.api.message.DefaultMultiPartPayload.BODY_ATTRIBUTES;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.MediaType;
-import org.mule.runtime.core.message.PartAttributes;
+import org.mule.runtime.core.api.message.PartAttributes;
 import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.runtime.extension.api.soap.SoapAttachment;
 import org.mule.runtime.soap.api.message.SoapAttributes;


### PR DESCRIPTION
_ Moving more classes from org.mule.runtime.core.message to api/internal