### PR TITLE
MULE-19615: Move third party dependencies in mule to runtime BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,6 +320,18 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>${jettyVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-security</artifactId>
+            <version>${jettyVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
             <version>${jettyVersion}</version>
             <scope>test</scope>


### PR DESCRIPTION
* Override managed jetty version as it was before jetty was managed

https://github.com/mulesoft/mule-runtime-bom/commit/b8cd8d8d74be25ee40a5193ac8246547c273997f#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R62