### PR TITLE
MULE-19615: Move third party dependencies in mule to runtime BOM (#252)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,6 +320,18 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>${jettyVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-security</artifactId>
+            <version>${jettyVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
             <version>${jettyVersion}</version>
             <scope>test</scope>


### PR DESCRIPTION
* Override managed jetty version as it was before jetty was managed

(cherry picked from commit 295943aa98518410790c7d437fd1e5f634e289f7)